### PR TITLE
Upgrade to LTS-12

### DIFF
--- a/lts-12.7.yaml
+++ b/lts-12.7.yaml
@@ -1,0 +1,5 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+resolver: lts-12.7


### PR DESCRIPTION
- Removed `Control.Monad.Trans.Either` with respect to `Control.Monad.Trans.Except`
- Corresponding LTS-12 yaml created.